### PR TITLE
fix typo

### DIFF
--- a/src/site/xdoc/jdo/annotations.xml
+++ b/src/site/xdoc/jdo/annotations.xml
@@ -2359,7 +2359,7 @@ public class MyClass
     @Embedded(members={
             @Persistent(name="field1", columns=@Column(name="OTHER_FLD_1")),
             @Persistent(name="field2", columns=@Column(name="OTHER_FLD_2"))
-        }
+        })
     MyOtherClass myField;
     ...
 }


### PR DESCRIPTION
added a missing bracket to the example for `@Embedded` in http://www.datanucleus.org/products/datanucleus/jdo/annotations.html#Embedded
