### PR TITLE
Added new L2 Cache update mode: datastore-read-only. With this mode L2 cache is only updated on datastre-read and NOT at commit. A custom commit listener can be made to control L2 cache population during commit if required.

### DIFF
--- a/src/main/asciidoc/jakarta/_persistence_emf.adoc
+++ b/src/main/asciidoc/jakarta/_persistence_emf.adoc
@@ -854,7 +854,7 @@ See also Cache docs link:#cache_level2[for Jakarta]
 
 |datanucleus.cache.level2.updateMode
 |When the objects in the L2 cache should be updated. Defaults to updating at commit AND when fields are read from a datastore object
-{*commit-and-datastore-read*, commit}
+{*commit-and-datastore-read*, commit-only, datastore-read-only}
 
 |datanucleus.cache.level2.cacheName
 |Name of the cache. This is for use with plugins such as the Tangosol cache plugin for accessing the particular cache. Please refer to the link:#cache_level2[L2 Cache docs]

--- a/src/main/asciidoc/jdo/_persistence_pmf.adoc
+++ b/src/main/asciidoc/jdo/_persistence_pmf.adoc
@@ -992,7 +992,7 @@ See also the link:persistence.html#cache_level2[Level 2 Cache docs]
 
 |datanucleus.cache.level2.updateMode
 |When the objects in the L2 cache should be updated. Defaults to updating at commit AND when fields are read from a datastore object
-{*commit-and-datastore-read*, commit}
+{*commit-and-datastore-read*, commit-only, datastore-read-only}
 
 |datanucleus.cache.level2.cacheName
 |Name of the cache. This is for use with plugins such as the Tangosol cache plugin for accessing the particular cache. 

--- a/src/main/asciidoc/jpa/_persistence_emf.adoc
+++ b/src/main/asciidoc/jpa/_persistence_emf.adoc
@@ -853,7 +853,7 @@ See also Cache docs link:#cache_level2[for JPA]
 
 |datanucleus.cache.level2.updateMode
 |When the objects in the L2 cache should be updated. Defaults to updating at commit AND when fields are read from a datastore object
-{*commit-and-datastore-read*, commit}
+{*commit-and-datastore-read*, commit-only, datastore-read-only}
 
 |datanucleus.cache.level2.cacheName
 |Name of the cache. This is for use with plugins such as the Tangosol cache plugin for accessing the particular cache. Please refer to the link:#cache_level2[L2 Cache docs]


### PR DESCRIPTION
Added new L2 Cache update mode: datastore-read-only. With this mode L2 cache is only updated on datastre-read and NOT at commit. A custom commit listener can be made to control L2 cache population during commit if required.